### PR TITLE
Metazoa Static generation pipeline - 1st time commit

### DIFF
--- a/scripts/Generate_whatsnew_content.sh
+++ b/scripts/Generate_whatsnew_content.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+HOST=$1
+CORE_FILE=$2
+PIPE_OR_NO=$3
+
+if [[ -z $HOST ]] || [[ -z $CORE_FILE ]]; then
+
+	echo "usage: sh Generate_whatsnew_content.sh <HOST> <CORE LIST FILE>"
+	exit 0
+else
+	echo -e -n "- **Assembly and gene set data updated**\n- **Updated gene sets**\n- **New assembly for existing species**\n- **New species**\n- **Updated BioMarts for all gene and variation data**\n- **Updated pan-taxonomic gene trees and homologies**\n- **Planned updates**\n\n" > ./WhatsNewContent.md
+	while read CORE; do 
+	SCI_NAME=`$HOST -D $CORE -N -e "select meta_value from meta where meta_key = 'species.scientific_name';"`;
+	COMMON=`$HOST -D $CORE -N -e "select meta_value from meta where meta_key = 'species.common_name';"`;
+	ACC=`$HOST -D $CORE -N -e "select meta_value from meta where meta_key = 'assembly.accession';"`;
+	ESCAPE_ACC=`echo $ACC | sed 's/_/\\\_/g'`;
+	echo "  - _${SCI_NAME}_ ($COMMON, $ESCAPE_ACC)" | tee -a WhatsNewContent.md; done < $CORE_FILE
+
+fi
+
+# Test is running as standalone or within main static content wrapper:
+if [[ $PIPE_OR_NO != 'pipe' ]]; then
+	echo -e -n "\n* Generated WhatsNew (MD) content found here --> \t"
+	readlink -f ./WhatsNewContent.md
+fi
+
+
+exit 1

--- a/scripts/Image_resource_gather.sh
+++ b/scripts/Image_resource_gather.sh
@@ -1,0 +1,248 @@
+#!/usr/bin/env bash
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+## A basic wrapper to obtain licensing information related to species for which you have wikipedia JSON summary dumps
+
+## Get file image names from Wikipedia summary ".json" files. 
+
+JSON_WIKI_DIR_USER=$1
+CWD=$2
+
+##Vars for STDOUT colour formatting
+GREEN='\033[0;32m'
+PURPLE='\033[0;35m'
+RED='\033[0;31m'
+ORANGE='\033[0;33m'
+NC='\033[0m' # No Color
+
+## WIKI REST Api functions:
+function get_wiki_commonsURL (){
+
+	local FILE_IMAGE_NAME=$1
+	local SP_DIR_AND_NAME=$2
+	local BASEURL="https://commons.wikimedia.org/w/api.php?action=query&titles=Image:${FILE_IMAGE_NAME}&prop=imageinfo&iiprop=extmetadata&format=json"
+
+	echo "Getting Wikipedia Commons info for: $BASEURL"
+	wget -qq --header='accept: application/json; charset=utf-8' "$BASEURL" -O $SP_DIR_AND_NAME
+}
+
+function get_wiki_altImages (){
+
+	local BINOMIAL_SP=$1
+	local SP_DIR_AND_NAME=$2
+	local ALL_MEDIA_URL="https://en.wikipedia.org/api/rest_v1/page/media-list/${BINOMIAL_SP}"
+
+	echo "Getting alternate wiki species images (if available): $ALL_MEDIA_URL"
+	wget -qq --header='accept: application/json; charset=utf-8; profile="https://www.mediawiki.org/wiki/Specs/Media/1.3.1"' "$ALL_MEDIA_URL" -O ${SP_DIR_AND_NAME}_otherImages.json
+}
+
+if [[ -z $JSON_WIKI_DIR_USER ]]; then
+
+	echo "Usage: sh Image_resource_gather.sh <INPUT WIKI JSON(s) DIR>"
+	exit 0
+fi
+
+JSON_WIKI_DIR_FULL=`readlink -f $JSON_WIKI_DIR_USER`
+
+#Remove older files from past runs if present
+rm -f ${CWD}/wiki_sp2image.tsv
+rm -f ${CWD}/Download_species_image_from_url.sh
+rm -f ${CWD}/wiki_sp2image_NoMissing.tsv
+
+
+## Gather the main image information for each WIKI json file:
+for JSON in ${JSON_WIKI_DIR_FULL}/*.wiki.json
+do 
+	
+	# Get the main path+file name of each species being processed:
+	SPECIES=(`echo $JSON | sed -E 's/_core.+$//'`)
+	echo -e -n "\nProcessing wikipedia image information:\n --> $SPECIES\n"
+	echo -e -n "$SPECIES\t" >> wiki_sp2image.tsv
+
+	# Format species names, using binomial only and replacing space for %20
+	LC_BINOMIAL_SP=`echo $SPECIES | awk -F "/" {'print $NF'}`
+	#Make file name of (production_name) upper case as needed for static image files:
+	BINOMIAL_SP=${LC_BINOMIAL_SP^}
+	
+	#Obtain the source url from Wiki Json (wiki species landing page)
+	SOURCE_URL=`jq '.' $JSON | grep -A 1 -e "originalimage" | grep -e ".jpg" -e ".JPG" -e ".png" -e ".PNG" | tail -n 1 | awk -F": " {'print $2'} | sed 's/[",]//g'`
+	#Replace all instances of encoded "(,) - %28/ %29 which I found interfered with obtaining image licensing information"
+	MEDIA_VIEW_BASE_URL="https://en.wikipedia.org/wiki/File"
+	IMAGE_NAME=`echo $SOURCE_URL | awk -F"/" '{print $NF}' | sed -E 's/[",]//g' | sed 's/%28/(/' | sed 's/%29/)/' | sed -E 's/[0-9]+px-//'`  
+	TARGET_IMAGE_URL="${MEDIA_VIEW_BASE_URL}:${IMAGE_NAME}"
+	FORMAT=`echo $IMAGE_NAME | awk -F"." '{print $NF}'`
+	PROD_IMAGE=${JSON_WIKI_DIR_FULL}/$BINOMIAL_SP.${FORMAT}
+
+	## First check if we have image licensing information on the main image, if not look up information on all images available: /page/media-list/{title}
+	if [ $IMAGE_NAME ]; then
+
+		# Format species names, using binomial only and replacing space for %20
+		FORMATED_BINOMIAL_SP=`echo $LC_BINOMIAL_SP | awk -F "_" {'print $1,$2'} | sed 's/ /%20/'`
+		ALL_MEDIA_URL="https://en.wikipedia.org/api/rest_v1/page/media-list/${FORMATED_BINOMIAL_SP}"
+
+		#Download all available media from wiki
+		LICENSE_JSON_URL="$(get_wiki_commonsURL $IMAGE_NAME ${SPECIES}_primaryImage_commonLicense.tmp.json)"
+
+		#Check if there are images assoicated with a given species image file name. Unless jq query returns pages: >0 there are not images associated with species landing page
+		CHECK_NULL=`cat ${SPECIES}_primaryImage_commonLicense.tmp.json | jq '.query.pages."-1"'`
+
+		# Now check if there is actual meta commons info to parse, otherwise try any other images that may be available
+		if [[ "$CHECK_NULL" =~ 'null' ]]; then
+			echo -e -n "${GREEN}Commons license retrieved for the primary wikipedia species image: $IMAGE_NAME${NC}\n"
+
+			#Control var for file tidy
+			ALT_JSONS_MADE="NO"
+			rm ${SPECIES}_primaryImage_commonLicense.tmp.json
+		else	
+			echo -e -n  "${ORANGE}WARNING: No license info available for primary wiki image: $IMAGE_NAME${NC}\n"
+			echo "....Checking if alternate wiki image(s) are available!"
+			rm ${SPECIES}_primaryImage_commonLicense.tmp.json
+
+			#Control var for file tidy
+			ALT_JSONS_MADE="YES"
+
+			#Download the alternate images JSON
+			get_wiki_altImages $FORMATED_BINOMIAL_SP $SPECIES
+
+			## Get Secondary species image file name(s)
+			cat ${SPECIES}_otherImages.json | jq '.items[] | select(.section_id=='0') | select(.leadImage==false).title' > ${SPECIES}.listed.alternative.images.txt
+			# echo "Other images to test for licensing information:"
+			while read ALT_IMAGE
+			do	
+				ALT_IMAGE=`echo $ALT_IMAGE | sed 's/"//g' | sed 's/File://g'`
+				LICENSE_JSON_URL="$(get_wiki_commonsURL $ALT_IMAGE ${SPECIES}_altImage_commonLicense.json)"
+
+				# Recheck if commons license info on alt image is available:
+				CHECK_NULL_2=`cat ${SPECIES}_altImage_commonLicense.json | jq '.query.pages."-1"'`
+				if [[ "$CHECK_NULL_2" =~ 'null' ]]; then
+					# echo "THERE IS LICENSE ON THE ALTERNATE IMAGE: $ALT_IMAGE"
+					TMP_ALT_IMAGE=`cat ${SPECIES}_otherImages.json | jq '.items[] | select(.section_id=='0') | select(.leadImage==false).srcset' | grep -e 'src' | head -n 1 | awk -F ": " {'print $2'} | sed 's/[",]//g'`
+					ALT_IMAGE_URL="https:${TMP_ALT_IMAGE}"
+					IMAGE_NAME=$ALT_IMAGE
+					TARGET_IMAGE_URL=$ALT_IMAGE_URL
+					SOURCE_URL=$ALT_IMAGE_URL
+				else
+					echo -e -n "${RED}WARNING: No wikicommons license info located on non-primary species image: $ALT_IMAGE${NC}\n"
+				fi	
+			done < ${SPECIES}.listed.alternative.images.txt
+		fi
+
+		#Check if we needed to retrieve other wiki JSONs for non-primary files
+		if [[ $ALT_JSONS_MADE == "YES" ]];then 
+		mkdir -p ${SPECIES}_intermedidate_wiki/;
+
+		#Tidy up files
+		for INTER_FILE in _otherImages.json _altImage_commonLicense.json .listed.alternative.images.txt
+			do
+				mv ${SPECIES}${INTER_FILE} ${SPECIES}_intermedidate_wiki/
+			done
+		fi
+	fi
+
+	if [ $IMAGE_NAME ]; then
+		echo -e -n "$IMAGE_NAME\t$TARGET_IMAGE_URL\n"  >> wiki_sp2image.tsv
+		echo -e -n "echo \"Downloading species image: $IMAGE_NAME\"\n" >> Download_species_image_from_url.sh
+		echo -e -n "wget -qq '$SOURCE_URL' -O $PROD_IMAGE\n" >> Download_species_image_from_url.sh
+
+		# Sleep for ~20s or we get throttled by wiki for to many concurrent connection requests:
+		echo -e -n "sleep 20\n" >> Download_species_image_from_url.sh
+	else
+		echo "**NO SPECIES IMAGE FOUND**" >> wiki_sp2image.tsv
+	fi
+done
+
+echo -e -n "\n\n${RED}***** Unavailable image resources. JSON file(s) *****\n"
+cat wiki_sp2image.tsv | grep -e "NO SPECIES IMAGE FOUND" | awk {'print $1'}
+echo -e -n "****************************************************${NC}\n\n"
+cat wiki_sp2image.tsv | grep -v "NO SPECIES IMAGE FOUND" > wiki_sp2image_NoMissing.tsv
+
+## Move all species source image files into single folder
+if [[ -e ${CWD}/Download_species_image_from_url.sh ]]; then
+
+	echo -e -n "!! Downloading all original species source images to folder [20s timeout between image retrieval]:\n--> \"${CWD}/Source_Images_wikipedia\" !!\n\n"
+
+	sh ${CWD}/Download_species_image_from_url.sh
+	mkdir -p $CWD/Source_Images_wikipedia
+	grep -e 'wget' Download_species_image_from_url.sh | awk -F" " '{print $NF}' | xargs -n 1 -I XXX mv XXX $CWD/Source_Images_wikipedia
+ 
+else
+	echo "${RED}WARNING: No source images were located !! Noting to do...Exiting !!${NC}"
+	exit 1
+fi
+
+#Check we don't rewrite over a previous run in case of loss of data
+if [ -e ./Output_Image_Licenses.final.tsv ]; then
+	mv ./Output_Image_Licenses.final.tsv ./OLD_Image_Licenses.tsv
+	echo -e -n "\nPreviously generated wiki license TSV retained as \"OLD_Image_Licenses.tsv\"\n\n"
+fi
+
+## Gather licensing information for each image file name
+if [[ -e ${CWD}/wiki_sp2image_NoMissing.tsv ]]; then
+
+	echo -e -n "\nBeginning to process image licensing meta info from Wikicommons....\n\n"
+	while read LINE
+	do
+
+	SPECIES_JSON=`echo $LINE | awk {'print $1'}`
+	SPECIES_ONLY=`echo $LINE | awk {'print $1'} | awk -F"/" {'print $NF'}`
+	IMAGE=`echo $LINE | awk {'print $2'}`
+	IMAGE_URL=`echo $LINE | awk {'print $3'} | sed 's/%28/(/' | sed 's/%29/)/' | sed -E 's/[0-9]+px-//'`
+
+	# Get commons meta info on downloaded image file:
+	LICENSE_JSON_URL="$(get_wiki_commonsURL $IMAGE ${SPECIES_JSON}_meta_license.json)"
+
+	
+	USAGETERM=`jq '.' ${SPECIES_JSON}_meta_license.json | grep -A 1 -e "UsageTerms" | \
+	tail -n 1 | awk -F":" {'print $2'} | sed -E 's/[",]//g' | sed 's/^ //'`
+	COMMONS_URL=`jq '.' ${SPECIES_JSON}_meta_license.json | grep -A 1 -e "LicenseUrl" | \
+	tail -n 1 | awk -F" " {'print $2'} | sed -E 's/[",]//g' | sed 's/^ //'`
+	
+	## Check what kind of usage terms is defined on license, common usage or specific usage:
+	if [[ $USAGETERM == 'Public domain' ]]; then
+		echo -e -n "$SPECIES_ONLY =>\tPicture credit: [${USAGETERM}](https://commons.wikimedia.org/wiki/Main_Page) via Wikimedia Commons [(Image source)](${IMAGE_URL})\n\n" >> Output_Image_Licenses.final.tsv
+	else
+		echo -e -n "$SPECIES_ONLY =>\tPicture credit: [${USAGETERM}](${COMMONS_URL}) via Wikimedia Commons [(Image source)](${IMAGE_URL})\n\n" >> Output_Image_Licenses.final.tsv
+	fi
+	done < wiki_sp2image_NoMissing.tsv
+	
+	
+	echo -e -n "${PURPLE} **** Finalised Image License Meta Info ******${NC}\n\n"
+	#Cleanup tmp files
+	mkdir -p $CWD/Commons_Licenses; mv ${JSON_WIKI_DIR_FULL}/*_meta_license.json ${CWD}/Commons_Licenses
+	rm ${CWD}/wiki_sp2image_NoMissing.tsv
+
+	# Print to screen the main licensing information gathered per species/core
+	cat Output_Image_Licenses.final.tsv
+
+	# Replace the captured image license information into each of the corresponding MD files
+	# Correspondance is via bionomial species name
+	cat Output_Image_Licenses.final.tsv | sed 's/ =>//g' | sed '/^$/d' | grep -v -e "Picture credit: \[\]()" > temp_output_license.tsv
+else
+
+	echo "${ORANGE}No source images located. Nothing to do !!"
+	exit 1
+
+fi
+
+echo -e -n "${GREEN}* Finished Species image download stage !!!\n\n"
+
+exit 0
+
+## Image Magik commands:
+#convert +repage -background grey -gravity center -extent 1410x1410 -resize 80x60 image.jpg image.png
+
+#-extent >> to select region from an image (when its not square or where the image subject isn't centered or occupys the majority of the image.
+#-resize output image size

--- a/scripts/Json_and_GCF_into_Static_MD_Parser.pl
+++ b/scripts/Json_and_GCF_into_Static_MD_Parser.pl
@@ -1,0 +1,377 @@
+#!/usr/bin/env perl
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+use strict;
+use warnings;
+
+# This script will input a set of refseq annotation summary files, and use the information in them to capture the JSON output (already scraped from wiki) and combine the two into a single set of species specific 
+# static content markdown files
+
+use JSON;
+use Data::Dumper;
+use Text::Wrap;
+use Term::ANSIColor qw(:constants);
+
+# Set colour functionality, allows single line color printing without using "reset"
+$Term::ANSIColor::AUTORESET = 1;
+
+## Get dir inforatmion
+my $json_dir = $ARGV[0];
+my $refseq_dir = $ARGV[1];
+my $assembly_dir = $ARGV[2];
+my $species_cores_listed = $ARGV[3];
+my $species_refseq_urls = $ARGV[4];
+my $core_host = $ARGV[5];
+my $release = $ARGV[6];
+
+die "USAGE: Parse_json_GCF_into_StaticMD.pl <WIKI_JSON_DIR> <REFSEQ_ANNO_REPORT_DIR> <REFSEQ_ASM_STATS_DIR> <List_Ensembl_CORE_FILE> <Core(s) Host> <Run_Identifier>\n" unless (@ARGV==7);
+
+my @input_refseq_anno_summarys = <${refseq_dir}/*.refseq.anno.txt>;
+## For each refseq file, locate and combine its assoicated JSON wiki summary file on GCA/GCA number
+
+system ("mkdir -p ./StaticContent_MD_Output-${release}");
+
+print BLUE "\nParsing JSON/Refseq files\n\n";
+
+foreach my $refseq_sum_file (@input_refseq_anno_summarys){
+
+	print DARK GREEN "Beginning processing RefSeq annotation:\n[$refseq_sum_file]\n";
+
+	#Species specific static content folder
+	my $static_output_folder = "StaticContent_MD_Output-${release}";	
+
+	#Base species file name
+	my $assembly_file = $refseq_sum_file;
+	$assembly_file	=~ s/\.refseq\.anno\.txt/.assemblystats.txt/;
+	#$assembly_file	=~ s/REFSEQ_ANNO_OUT/REFSEQ_ASSEMMSTAT_OUT/;
+	$assembly_file	=~ s/RefSeq_Annotation_Reports/RefSeq_Assembly_Reports/;
+	
+	## Control flow and other control variables
+	my $has_wiki_json_data=0;
+	my $wrap_at = 70; #Length of each paragraph line printed.
+	my $wiki_about;
+	my $Anno_file_populated = 1;
+
+	#per core global vars
+	my ($scientific_name, $extract, $jpg_source, $wiki_url, $about_content, $annotation_content, $assembly_content);
+	
+	# RefSeq annotation report variables
+	my ($species_name, $common_name, $taxa_id, $anno_report, $asseb_accession, $release_version, @ncbi_rel);
+
+	# Convert GCF to GCA and locate its wiki JSON file
+	my ($refseq_file, $gcf_num, $gca_accession, $core_prodname, $gca_accession_escape);
+
+	my @split_refseq_path = split ("/", $refseq_sum_file);
+	$refseq_file = $split_refseq_path[-1];
+	my @split_refseq_file = split ("_", $refseq_file);
+	$gcf_num = $split_refseq_file[1];
+	$gcf_num =~ s/\.[0-9]$//;
+	$gcf_num = "gca".$gcf_num;
+
+	# Check if the RefSeq Annotation file is empty or populated:
+	if (-z $refseq_sum_file){
+		
+		print BOLD RED "RefSeq Annotation summary file :\t$refseq_sum_file\nAnnotation README file is empty. Need to approximate information from assembly report file instead!!\n";
+			
+		# Define unknown annotation report ftp and version
+        $Anno_file_populated = 0;
+
+		my $grep_raw_asm = `grep -e "Organism name" < $assembly_file`;
+		my @temp_split_rawname = split (": ", $grep_raw_asm);
+
+		if ($temp_split_rawname[1] =~ m/[A-Z][a-z]+ [a-z]+/){$scientific_name = $&;}
+		my $species_name_tmp = $scientific_name;		
+		$species_name_tmp =~ tr / /_/;
+		$static_output_folder = $static_output_folder."/".$species_name_tmp;
+		$species_name = lcfirst($species_name_tmp);
+
+		if ( $temp_split_rawname[1] =~ m/\(\w+ \w+\)/ ){$common_name = $&; $common_name =~ s/\(//g; $common_name =~ s/\)//g;}	
+		
+		my $temp_cn = ucfirst($common_name); $common_name = $temp_cn;
+		
+		#Get TaxonID from asm report file
+		$grep_raw_asm = `grep -e "Taxid" < $assembly_file`;
+		if ( $grep_raw_asm =~ m/\d+/ ){ $taxa_id = $&; chomp $taxa_id; }
+
+		$grep_raw_asm = `grep -e "GenBank assembly accession" < $assembly_file`;
+        
+		if ( $grep_raw_asm =~ m/GCA_\d+\.\d/ ){ 
+			
+			$gca_accession=$&;
+			chomp $gca_accession;
+			$core_prodname = $gca_accession;
+	        $gca_accession_escape = $gca_accession;
+        	$gca_accession_escape =~ s/GCA_/GCA\\_/;
+            $core_prodname =~ s/GCA_/gca/;
+            $core_prodname =~ s/\.[0-9]$//;
+            chomp $core_prodname;
+            $core_prodname = "${species_name}_${core_prodname}";
+		}
+
+	}# Ends test on missing anno report
+
+
+	## Parse species name from ref_seq annotion
+	unless (defined $species_name){	$species_name = `grep -e "ORGANISM NAME" < $refseq_sum_file | cut -f2`;
+	chomp $species_name;
+	$scientific_name = $species_name;
+	$species_name =~ tr/ /_/;
+	$static_output_folder = $static_output_folder."/".$species_name;
+	}
+	my @temp_split_sp_name = split ("_", $species_name);
+
+	#Check whether or not the species name is bionomial or trinomial
+	if ((scalar @temp_split_sp_name == 3 ) && ($temp_split_sp_name[1] eq $temp_split_sp_name[2])){
+		print YELLOW "!!! Found trinomial species name instance !!!! \"$species_name\" --> Utilizing just the bionomial: ";
+		$species_name = "$temp_split_sp_name[0]_$temp_split_sp_name[1]";
+		print "\"$species_name\"\n";
+	}
+	else{
+		print "Species name: \"$scientific_name\".\n";
+	}
+
+	$species_name = lc$species_name;
+	system ("mkdir -p ./$static_output_folder");
+
+	# Check if common name and Taxon ID was defined from Assembly report file, otherwise grab from Annotation report file
+	# Common name:
+	unless (defined $common_name ){ $common_name = `grep -e "^ORGANISM COMMON NAME" < $refseq_sum_file | cut -f2`; chomp $common_name; }
+	# Taxon ID:
+	unless (defined $taxa_id ){ $taxa_id = `grep -e "^TAXID" < $refseq_sum_file | cut -f2`; chomp $taxa_id; }
+
+
+	# Check if Annotation report was in place, otherwise we can't get annotation report ftp url and version
+	$anno_report = `grep -e "^ANNOTATION REPORT" < $refseq_sum_file | cut -f2`;
+	chomp $anno_report;
+	
+	## If Annotation report is avaialble, obtain annotation report url and release version.
+	if ($Anno_file_populated == 1 ){
+		@ncbi_rel = split ("/",$anno_report);
+		$release_version = $ncbi_rel[-1];
+		$asseb_accession = `grep -e "^ASSEMBLY ACCESSION" < $refseq_sum_file | cut -f2`;
+        chomp $asseb_accession;
+        $gca_accession = $asseb_accession;
+        $gca_accession =~ s/GCF_/GCA_/;
+        $core_prodname = $gca_accession;
+        $gca_accession_escape = $gca_accession;
+        $gca_accession_escape =~ s/GCA_/GCA\\_/;
+        $core_prodname =~ s/GCA_/gca/;
+        $core_prodname =~ s/\.[0-9]$//;
+        chomp $core_prodname;
+        $core_prodname = "${species_name}_${core_prodname}";
+	}
+	else{
+		my $GCF_from_GCA = $gca_accession;
+		$GCF_from_GCA =~ s/GCA_/GCF_/;
+		my $grep_acc_for_refseq = `grep -e "$GCF_from_GCA" < $species_refseq_urls`;
+		chomp $grep_acc_for_refseq;
+		
+		#Now redefine Annotation report URL and release version to be the RefSeq FTP url
+		$anno_report = $grep_acc_for_refseq;
+		$release_version = "ersion is not defined for $gca_accession assembly";
+	}
+	
+	#Initial attempt to locate the correct core DB.
+	my $species_core = `grep -E "^${core_prodname}" < $species_cores_listed\n`;
+	chomp $species_core;
+
+	#Find the coreDB from the input core list file. Then locate the appropriate JSON file to parse. 
+	my ($json_file_name, $json_file_path);
+
+	#Test if core was found based on inclusion of GCA_ in the name
+	if ($species_core){
+		print "Core DB located: $species_core\n";
+		$json_file_name = "$species_name"."_"."$gcf_num";
+		$json_file_path = `ls -1 ${json_dir}/${json_file_name}*`;
+		chomp $json_file_path;
+		#print "JSON_FILE_PATH = $json_file_path\n";
+	}
+	else{
+		print YELLOW "No core DB containing \"_gca\" accession found [$asseb_accession].\n";
+
+		$species_core = `grep -E "^${species_name}_core_[0-9]{2}_[0-9]{3}_[0-9]{1}" < $species_cores_listed\n`;
+		chomp $species_core;
+		print YELLOW "Located core instead: $species_core\n";
+		$json_file_path = `ls -1 ${json_dir}/${species_core}.wiki.json`;
+		chomp $json_file_path;
+	}
+
+	#Perform query to obtain production name from to ensure static md will match with ensembl core DB
+	system("$core_host -D $species_core -e \"SELECT meta_value FROM meta WHERE meta_key = 'species.production_name';\" | tail -n 1 > temp_sql.txt");
+	my $prod_name=`cat temp_sql.txt`;
+	chomp $prod_name;
+	$prod_name = ucfirst($prod_name);
+	system("rm ./temp_sql.txt");
+	print "Linked with Ensembl CORE_DB [$species_core] & species.production_name [$prod_name]\n";
+
+	##Open file handles using species.productioin_name to write markdown .md files.
+	open (OUT_ABOUT, ">${prod_name}_about.md") || die "Can\'t open ${prod_name}_about.md\n";
+	open (OUT_ANNO, ">${prod_name}_annotation.md") || die "Can\'t open ${prod_name}_annotation.md\n";
+	open (OUT_ASM, ">${prod_name}_assembly.md") || die "Can\'t open ${prod_name}_assembly.md\n";
+ 
+	# printf "The species %s, otherwise known as the %s.\nTaxon_id=%d\nWas obtained with annotation from %s\nWhich is associated with acc:%s\n", $species_name, $common_name, $taxa_id, $anno_report, $asseb_accession;
+
+	## Parse specifc assembly statistics from asm file
+	my ($total_asm_len, $scaffold_count, $scaf_N50, $scaf_L50, $contig_count, $cont_N50, $cont_L50, $gc_perc, $total_gap_length);
+
+	$total_asm_len = `grep -E "^all.+total-length" < $assembly_file | cut -f6`;
+	$scaffold_count = `grep -E "^all.+scaffold-count" < $assembly_file | cut -f6`;
+	chomp ($scaffold_count, $total_asm_len);
+
+	#Check if scaffolds are accounted for or contigs
+	if ($scaffold_count eq ""){
+
+		# print "!!!!!!!!!Entered Contig section !!!!!!!!!!!!!!\n";
+		$contig_count = `grep -E "^all.+contig-count" < $assembly_file | cut -f6`;
+		$cont_N50 = `grep -E "^all.+contig-N50" < $assembly_file | cut -f6`;
+		$cont_L50 = `grep -E "^all.+contig-L50" < $assembly_file | cut -f6`;
+		$total_gap_length = `grep -E "^all.+total-gap-length" < $assembly_file | cut -f6`;
+		$gc_perc = `grep -E "^all.+gc-perc" < $assembly_file | cut -f6`;
+
+		chomp ($contig_count, $cont_N50, $cont_L50, $total_gap_length, $gc_perc);
+
+		if (!$gc_perc){
+			# $gc_perc="0.0";
+			## Print out the assembly summary infortmation without mentioning the absent asm GC%
+			printf OUT_ASM "**Assembly**\n--------\n\nThe assembly presented here has been imported from [INSDC](http:\/\/www.insdc.org) and is linked to the assembly accession [[%s](http:\/\/www.ebi.ac.uk\/ena\/data\/view\/%s)].\n\nThe total length of the assembly is %d bp contained withinin %d contigs.\nThe contig N50 value is %d, the contig L50 value is %d.\nAssembly gaps span %d bp.\n",$gca_accession_escape, $gca_accession, $total_asm_len, $contig_count, $cont_N50, $cont_L50, $total_gap_length;
+
+		}
+		else{
+			## Print out the assembly summary infortmation without mentioning the absent asm GC%
+			printf OUT_ASM "**Assembly**\n--------\n\nThe assembly presented here has been imported from [INSDC](http:\/\/www.insdc.org) and is linked to the assembly accession [[%s](http:\/\/www.ebi.ac.uk\/ena\/data\/view\/%s)].\n\nThe total length of the assembly is %d bp contained withinin %d contigs.\nThe contig N50 value is %d, the contig L50 value is %d.\nAssembly gaps span %d bp. The GC%% content of the assembly is %.1f%%.\n",$gca_accession_escape, $gca_accession, $total_asm_len, $contig_count, $cont_N50, $cont_L50, $total_gap_length, $gc_perc;
+		}
+	}
+	else{
+
+		# print "!!!!!!!!!Entered Scaffold section !!!!!!!!!!!!!!\n";
+		$scaf_N50 = `grep -E "^all.+scaffold-N50" < $assembly_file | cut -f6`;
+		$scaf_L50 = `grep -E "^all.+scaffold-L50" < $assembly_file | cut -f6`;
+		$total_gap_length = `grep -E "^all.+total-gap-length" < $assembly_file | cut -f6`;
+		$gc_perc = `grep -E "^all.+gc-perc" < $assembly_file | cut -f6`;
+
+		chomp ($scaf_N50, $scaf_L50, $total_gap_length, $gc_perc);
+
+		if (!$gc_perc){
+			# $gc_perc="0.0";
+			printf OUT_ASM "**Assembly**\n--------\n\nThe assembly presented here has been imported from [INSDC](http:\/\/www.insdc.org) and is linked to the assembly accession [[%s](http:\/\/www.ebi.ac.uk\/ena\/data\/view\/%s)].\n\nThe total length of the assembly is %d bp contained withinin %d scaffolds.\nThe scaffold N50 value is %d, the scaffold L50 value is %d.\nAssembly gaps span %d bp.\n",$gca_accession_escape, $gca_accession, $total_asm_len, $scaffold_count, $scaf_N50, $scaf_L50, $total_gap_length;
+		}
+		else{
+			## Print out the assembly summary infortmation
+			printf OUT_ASM "**Assembly**\n--------\n\nThe assembly presented here has been imported from [INSDC](http:\/\/www.insdc.org) and is linked to the assembly accession [[%s](http:\/\/www.ebi.ac.uk\/ena\/data\/view\/%s)].\n\nThe total length of the assembly is %d bp contained withinin %d scaffolds.\nThe scaffold N50 value is %d, the scaffold L50 value is %d.\nAssembly gaps span %d bp. The GC%% content of the assembly is %.1f%%.\n",$gca_accession_escape, $gca_accession, $total_asm_len, $scaffold_count, $scaf_N50, $scaf_L50, $total_gap_length, $gc_perc;
+		}
+	}
+
+
+	## Test if the JSON file is empty, if yes raise a warning and produce a placeholder summary in about.md static file to be filled in manually later. 
+	unless (-z $json_file_path){
+		$has_wiki_json_data = 1;
+	}
+	else{
+		print BOLD RED "Wikipedia summary information not found in JSON file: $json_file_path\t<----Skipping parse. Manual editing required for this species !!\n";
+
+		$about_content = "**About *$scientific_name***
+-------------------------
+!!!!!! PLACEHOLDER SUMMARY. MANUAL EDIT REQUIRED HERE !!!!!!
+
+Picture credit: [LICENSE TYPE]() via Wikimedia Commons [(Image source)]()
+
+Taxonomy ID [$taxa_id](https://www.uniprot.org/taxonomy/${taxa_id})
+
+(Text from [Wikipedia](https://en.wikipedia.org/).)
+
+**More information**
+General information about this species can be found in [Wikipedia](https://en.wikipedia.org/wiki/${species_name})\n";
+	
+	print OUT_ABOUT $about_content;
+	}
+
+#check if a file has JSON before attempting to parse it
+if ($has_wiki_json_data == 1){
+		my $fixed_json;
+		$fixed_json = "${json_file_path}.fixed";
+		my $file_contents = `cat $json_file_path`;
+		chomp $file_contents;
+		$fixed_json =~ s/\.json\.fixed/.fixed.json/;
+			open(TEMPOUT, ">$fixed_json") || die "can't open $fixed_json\n";
+			print TEMPOUT "[".$file_contents."]";
+			close TEMPOUT;
+	
+		my $json_text = do {
+		open(my $json_fh, "<:encoding(UTF-8)", $fixed_json) or die ("Can't open JSON file: $fixed_json: $!\n");
+		local $/;
+		<$json_fh>
+		};
+	
+		# Create JSON object and data vars we want to capture
+		my $json_ob = JSON->new;
+		my $jsondata = $json_ob->decode($json_text);
+		# print Dumper(\$jsondata);
+	
+		# Extract data from json.
+		foreach (@$jsondata){
+			$extract = $_->{extract};
+			$extract =~ s/$scientific_name/\*$scientific_name\*/;
+			$extract =~ s/$common_name/$common_name (*$scientific_name*)/;
+			$jpg_source = $_->{'thumbnail'}{'source'};
+			$wiki_url = $_->{'content_urls'}{'desktop'}{'page'};
+		}
+		#Wrap the summary text
+		($wiki_about = $extract) =~ s/(.{0,$wrap_at}(?:\s|$))/$1\n/g;
+
+$about_content = "**About *$scientific_name***
+-------------------------
+$wiki_about
+Picture credit: [LICENSE TYPE]() via Wikimedia Commons [(Image source)]($jpg_source)
+
+Taxonomy ID [$taxa_id](https://www.uniprot.org/taxonomy/${taxa_id})
+
+(Text from [Wikipedia](https://en.wikipedia.org/).)
+
+**More information**
+General information about this species can be found in [Wikipedia]($wiki_url)\n";
+	
+print OUT_ABOUT $about_content;
+
+	}
+
+$annotation_content = "**Annotation**
+----------
+
+The annotation presented is derived from annotation submitted to
+[INSDC](http:\/\/www.insdc.org) with the assembly accession [$gca_accession_escape](http:\/\/www.ebi.ac.uk\/ena\/data\/view\/$gca_accession).
+
+Ensembl Metazoa displaying genes imported from [NCBI RefSeq]($anno_report) annotation release v${release_version}.
+Small RNA features, protein features, BLAST hits and cross-references have been
+computed by [Ensembl Metazoa](https://metazoa.ensembl.org/info/genome/annotation/index.html).
+";
+
+print OUT_ANNO $annotation_content;
+
+system ("mv ./*.md ./$static_output_folder");
+
+## Close outfiles
+close OUT_ANNO;
+close OUT_ABOUT;
+close OUT_ASM;
+
+print BRIGHT_GREEN "\t** Finished processing **\n\n";
+
+}
+
+system("rm ${json_dir}/*.fixed.json");
+
+exit;
+

--- a/scripts/Update_image_licenses.pl
+++ b/scripts/Update_image_licenses.pl
@@ -1,0 +1,83 @@
+#!/usr/bin/env perl
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Set colour functionality, allows single line color printing without using "reset"
+use Term::ANSIColor qw(:constants);
+$Term::ANSIColor::AUTORESET = 1;
+
+## A script to transfer the license info from Image_resource_gather.sh into static MD files.
+
+my $infile = <temp_output_license.tsv>;
+my $release = $ARGV[0];
+my $CWD = $ARGV[1];
+chomp $CWD;
+my $release_dir = "StaticContent_MD_Output-${release}";
+
+if(!open(INFILE,"<",$infile))
+{
+print "Missing inputfile: temp_output_license.tsv. Exiting\n";
+exit 1;
+}
+
+open (INFILE, "<$infile");
+while (<INFILE>){
+
+    my $curr_line = $_;
+    chomp $curr_line;
+    my @split_line = split ("\t", $curr_line);
+
+    my $sp_name = @split_line[0];
+    $sp_name = ucfirst($sp_name);
+    my $license_full = @split_line[1];
+    print "Processing species: $sp_name\n";
+    
+    my $binomial_sp = $sp_name;
+    $binomial_sp =~ s/_gca[0-9]+v[0-9][cm|fb|gb|rs|vb|wb]*.?//g;
+    $binomial_sp = ucfirst($binomial_sp);    
+
+    # Gather paths+files for new and original '_about' MD files
+    my $MD_about_file = $CWD."/".$release_dir."/$binomial_sp/${sp_name}_about.md";
+    my $MD_about_file_old = "${MD_about_file}.old";
+    system("mv $MD_about_file $MD_about_file_old");
+
+    my $temp_MD_about_file = "${CWD}/temp_about_file.md";
+    open (ABOUT_FILE, "<$MD_about_file_old") || die "Can\'t open MD about file to parse\n";
+    open (NEW_ABOUT_FILE, ">>temp_about_file.md") || "Can\'t open outfile\n";
+
+    while (<ABOUT_FILE>){
+        unless ($_ =~ m/^Picture credit/){
+            print NEW_ABOUT_FILE $_;
+        }
+        else{
+            print NEW_ABOUT_FILE "$license_full";
+        }
+    }
+    close ABOUT_FILE;
+    close NEW_ABOUT_FILE;
+
+    system("mv $temp_MD_about_file $MD_about_file");
+}
+
+#Close input and remove the temporary license file
+close INFILE;
+
+system("rm ${CWD}/temp_output_license.tsv");
+# print "Looking for old MD files\n";
+system("find ${CWD}/${release_dir}/ -type f -name \"*_about.md.old\" | xargs -n 1 -I XXX rm XXX");
+
+print BRIGHT_GREEN "* Finished updating species *_about.md files <--> On Wiki Image licenses.\n\n";
+
+exit 0

--- a/scripts/WikipediaREST_RefSeq_2_static_wrapper.sh
+++ b/scripts/WikipediaREST_RefSeq_2_static_wrapper.sh
@@ -1,0 +1,282 @@
+#!/usr/bin/env bash
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+## Main EnsMetazoa static content wrapper:
+## Obtain from Wikipedia/RefSeq summary, annotation and assembly information and produce relevant static content markdown files (.md, image.jpg/png etc).
+
+## NOTE *** REFSEQ urls passed MUST be related to species with annotation (GFC_). Genbank/GCA_ based assemblies will not produce the desired outputs.
+
+RUN_STAGE=$1
+INPUT_DB_LIST=$2
+INPUT_REFSEQ_URL=$3
+HOST=$4 #MYSQL server hosting the cores listed in $INPUT_DB_LIST. Can be short name e.g. st3b
+RELEASE=$5
+
+##Vars for STDOUT colour formatting
+GREEN='\033[0;32m'
+PURPLE='\033[0;35m'
+RED='\033[0;31m'
+ORANGE='\033[0;33m'
+NC='\033[0m' # No Color
+
+###Check for required env variables 
+# WorkDir ENV
+if [[ -z $MAIN_BASE_DIR ]]; then
+	MAIN_BASE_DIR=`readlink -f $PWD`
+	echo -e "${ORANGE}**Work base MAIN_BASE_DIR environment var not defined. Setting to CWD !**"
+	echo -e -n "--->\"$MAIN_BASE_DIR\"${NC}\n\n"
+else
+	echo -e -n "${GREEN}Base work directory 'MAIN_BASE_DIR' defined !\n---> \"$MAIN_BASE_DIR\"\n\n"
+fi
+# Location of ensembl-production-metazoa:
+if [[ -z $ENS_MAIN_METAZOA_PROD ]]; then
+	echo -e -n "**Location of 'ensembl-production-metazoa' repo not defined !**\nChecking here: 'MAIN_BASE_DIR'\n"
+
+	if [[ -d ${MAIN_BASE_DIR}/ensembl-production-metazoa ]]; then
+			echo -e -n "${GREEN}SUCCESS: Located local clone of '${MAIN_BASE_DIR}/ensembl-production-metazoa'.${NC}\n\n"
+			ENS_MAIN_METAZOA_PROD="${MAIN_BASE_DIR}/ensembl-production-metazoa"
+	else
+			echo -e -n "${RED}FAILED: Please define environment var 'ENS_MAIN_METAZOA_PROD' with full path to /ensembl-production-metazoa repo.${NC}\n\nExiting !!\n"
+			exit
+	fi
+fi
+
+
+## Basic run case: Generate some tempalte markdown files to be filled in manually
+if [[ $RUN_STAGE == template ]]; then
+
+	# ### Generate blank files for species not linked with GCF_
+	read -p "Generating blank MD files for single species. Enter species.production_name : " PROD_NAME
+
+	BINOMIAL=`echo ${PROD_NAME^} | sed 's/_/ /g'`
+
+	for EXTENSION in _about.md _annotation.md _assembly.md
+		do
+		cp ${ENS_MAIN_METAZOA_PROD}/scripts/template${EXTENSION} $MAIN_BASE_DIR/${PROD_NAME}${EXTENSION};
+		done
+	echo -e -n "\n${GREEN}Generated generic template Markdown files:${NC}\n[${PROD_NAME}_about.md, ${PROD_NAME}_annotation.md, ${PROD_NAME}_assembly.md]\n\n \
+${ORANGE}!!! Please amend these files and fill in the required meta info !!!${NC}\n\nBasic run finished. Exiting.\n"
+	
+	sed -i "s/scientific_name/$BINOMIAL/" $MAIN_BASE_DIR/${PROD_NAME}_about.md;
+	exit 0
+fi
+
+## Main run case: Automatted processing of multiple species static content:
+if [[ -z $INPUT_DB_LIST ]] || [[ -z $INPUT_REFSEQ_URL ]] || [[ -z $HOST ]] || [[ -z $RELEASE ]]; then
+
+ 	echo -e -n "#Basic usage (Generate template MD static files):\n---> 'sh WikipediaREST_RefSeq_2_static_wrapper.sh template'\n\n"
+ 	echo "-- OR --"
+ 	echo -e -n "\n#Automated processing usage:\n---> 'sh WikipediaREST_RefSeq_2_static_wrapper.sh <RunStage: All, Wiki, NCBI, Static, Image, WhatsNew, Tidy> <INPUT_DB_LIST> <INPUT_REFSEQ_URLS> <MYSQL_SERVER> <Unique_Run_Identifier>'\n"
+
+ 	exit 0
+fi
+
+HOST_NAME=`echo $($HOST details url) | awk 'BEGIN{FS="[@:/]";}{print $5}'`
+OUTPUT_JSONS="$MAIN_BASE_DIR/WIKI_JSON_OUT"
+TRACKING="$MAIN_BASE_DIR/${RELEASE}_checkDone"
+mkdir -p $TRACKING
+
+## Stage one: Obtain wikipedia JSON for each species
+if [[ $RUN_STAGE == "All" ]] || [[ $RUN_STAGE == "Wiki" ]]; then 
+
+	mkdir -p $OUTPUT_JSONS
+
+	#Make sure to remove any old generate_Wiki_JSON_Summary.sh 
+	if [[ -e $MAIN_BASE_DIR/generate_Wiki_JSON_Summary.sh ]]; then
+		echo "Deleting old generate_Wiki_JSON_Summary.sh"
+		rm $MAIN_BASE_DIR/generate_Wiki_JSON_Summary.sh
+	fi
+
+	echo -e -n "${ORANGE}Downloading Wikipedia information (JSON):${NC}\n\n"
+	## Generate the list of wikipedia_urls and generate WGET cmds for JSON summary retrival
+	while read CORE
+	do
+		echo -e -n "-- On species linked to core_db: $CORE\n";
+		SCI_NAME=`$HOST_NAME -D $CORE -e "select meta_value from meta where meta_key = \"species.scientific_name\";" | tail -n 1 | tr " " "_"`
+		echo -e -n "Scientific name: $SCI_NAME\n\n"
+		FORMAT_SCI_NAME=`echo $SCI_NAME | sed 's/_/%20/'`;
+		echo $SCI_NAME | xargs -n 1 -I XXX echo "https://en.wikipedia.org/wiki/XXX" >> Wikipedia_URL_listed.check.txt
+		echo "wget -qq --header='accept: application/json; charset=utf-8' --header 'Accept-Language: en-en' 'https://en.wikipedia.org/api/rest_v1/page/summary/$FORMAT_SCI_NAME?redirect=true' -O ${CORE}.wiki.json" >> $MAIN_BASE_DIR/generate_Wiki_JSON_Summary.sh
+	done < $INPUT_DB_LIST
+
+	## Run the JSON REST wgets and place inside a folder:
+	sh $MAIN_BASE_DIR/generate_Wiki_JSON_Summary.sh
+	mv $MAIN_BASE_DIR/*.json $OUTPUT_JSONS
+
+	##Find out which species have not got any wikipedia information
+	find $OUTPUT_JSONS -empty | awk 'BEGIN{FS="/";}{print $NF}' >> Without_Wikipedia_Summary_Content.txt
+
+	# Generate tracking files and set run next stage
+	touch ${TRACKING}/_s1_wiki_gather
+	RUN_STAGE="NCBI"
+
+fi
+
+## Stage two: OUTPUT FROM & 2 FILES: 1) Wikipedia urls to check (Done manually), 2) List of wget cmds to scrape Wiki summarys from Wikimedia REST API
+if [[ $RUN_STAGE == "All" ]] || [[ $RUN_STAGE == "NCBI" ]]; then 
+
+	if [[ -e $TRACKING/_s1_wiki_gather ]]; then
+
+		echo -e -n "\n\n${ORANGE}*** Now gathering NCBI assembly and annotation summary files.....${NC}\n"
+		## Get annotation release reports
+		while read URL
+		do
+			GCF_name=`echo $URL | awk 'BEGIN{FS="/";} {print $NF}'`
+			echo $URL | xargs -n 1 -I XXX sh -c '
+			wget -qq XXX -O - |
+			grep -P "README_.*_annotation_release_.*" |
+			cut -f 2 -d \" |
+			xargs -n 1 -I YYY wget -qq XXX/YYY -O -
+			' |
+		cat > ${GCF_name}.refseq.anno.txt
+		done < $INPUT_REFSEQ_URL
+	
+		OUTPUT_REFSEQ_ANNO="$MAIN_BASE_DIR/RefSeq_Annotation_Reports"
+		mkdir -p $OUTPUT_REFSEQ_ANNO
+		mv $MAIN_BASE_DIR/*.refseq.anno.txt $OUTPUT_REFSEQ_ANNO
+	
+		## Get assembly stats reports
+		while read URL
+		do
+			GCF_name=`echo $URL | awk 'BEGIN{FS="/";} {print $NF}'`
+			echo $URL | xargs -n 1 -I XXX sh -c '
+			wget -qq XXX -O - |
+			grep -P "assembly_stats.txt" |
+			cut -f 2 -d \" |
+			xargs -n 1 -I YYY wget -qq XXX/YYY -O -
+			' |
+		cat > ${GCF_name}.assemblystats.txt
+		done < $INPUT_REFSEQ_URL
+	
+		OUTPUT_ASSEMB_STATS="$MAIN_BASE_DIR/RefSeq_Assembly_Reports"
+		mkdir -p $OUTPUT_ASSEMB_STATS
+		mv $MAIN_BASE_DIR/*.assemblystats.txt $OUTPUT_ASSEMB_STATS
+		## Output from above ^ set of files, one per RefSeq url which will need to be parsed into json format and then output as markdown.
+	
+		echo -e -n "${GREEN}*Finished generating NCBI resource wget commands.\n${NC}"
+	
+		# Generate tracking files and set run next stage
+		touch ${TRACKING}/_s2_ncbi_gather
+		RUN_STAGE="Static"
+	else
+		echo -e -n "${ORANGE}Must first run stage [1]: 'Wiki'${NC}\n"
+	fi
+fi
+
+## Stage three:  Run the main parser to generate static content and create ensembl-static dirs/*.md files.
+if [[ $RUN_STAGE == "All" ]] || [[ $RUN_STAGE == "Static" ]]; then
+	
+	if [[ -e $TRACKING/_s2_ncbi_gather ]]; then
+
+		echo -e -n "\n\n${ORANGE}*** Now running JSON to Static Parser in 5 secs.....OR - Stop here 'CTRL+C' and continue later by calling:${NC}\n \
+---> \"perl Json_and_GCF_into_Static_MD_Parser.pl  $OUTPUT_JSONS $OUTPUT_REFSEQ_ANNO $OUTPUT_ASSEMB_STATS $INPUT_DB_LIST $INPUT_REFSEQ_URL $HOST $RELEASE\"\n"
+		sleep 5
+		
+		perl $ENS_MAIN_METAZOA_PROD/scripts/Json_and_GCF_into_Static_MD_Parser.pl $OUTPUT_JSONS $OUTPUT_REFSEQ_ANNO $OUTPUT_ASSEMB_STATS $INPUT_DB_LIST $INPUT_REFSEQ_URL $HOST $RELEASE 2>&1 | tee StaticContent_Gen_${RELEASE}_${HOST}.log
+		
+		touch ${TRACKING}/_s3_generate_markdown
+		RUN_STAGE="Image"
+	else
+		echo -e -n "${ORANGE}Must first run stage [2]: 'NCBI'${NC}\n"
+	fi
+fi
+
+## Stage four:  Run the Wiki image resource gathering. Locate species images for each JSON dump file from earlier
+if [[ $RUN_STAGE == "All" ]] || [[ $RUN_STAGE == "Image" ]]; then
+	
+	if [[ -e $TRACKING/_s3_generate_markdown ]]; then
+
+		echo -e -n "\n\n${ORANGE}*** Gathering Species image resources from wikipedia.....${NC}\n\
+		---> \"Image_resource_gather.sh $OUTPUT_JSONS\"\n\n"
+		sh ${ENS_MAIN_METAZOA_PROD}/scripts/Image_resource_gather.sh $OUTPUT_JSONS $MAIN_BASE_DIR
+		
+		## Now Update any static '_about.md' markdown files with the relevant image resource licenses where they exist (Input being 'Output_Image_Licenses.tsv').
+		echo -e -n "\n\n${ORANGE}*** Updating species '_about.md' static files with full image license information${NC}\n\
+		---> \"Update_image_licenses.pl $RELEASE\"\n\n"
+		# sleep 5
+		
+		perl $ENS_MAIN_METAZOA_PROD/scripts/Update_image_licenses.pl $RELEASE $MAIN_BASE_DIR
+	
+		# Generate tracking files and set run next stage
+		touch ${TRACKING}/_s4_image_retrieval
+		RUN_STAGE="WhatsNew"
+	else
+		echo -e -n "${ORANGE}Must first run stage [3]: 'Static'${NC}\n"
+	fi
+fi
+
+## Stage five:  Run stage to generate whats_new.md file 
+if [[ $RUN_STAGE == "All" ]] || [[ $RUN_STAGE == "WhatsNew" ]]; then
+
+	if [[ -e $TRACKING/_s4_image_retrieval ]]; then
+	
+		echo -e -n "\n\n${ORANGE}*** Generating 'whats_new.md' file to output MD formated species content.....${NC}\n\
+		---> \"sh Generate_whatsnew_content.sh $INPUT_DB_LIST\"\n\n"
+		
+		sh $ENS_MAIN_METAZOA_PROD/scripts/Generate_whatsnew_content.sh $HOST $INPUT_DB_LIST 'pipe'
+		
+		if [[ -e $MAIN_BASE_DIR/StaticContent_MD_Output-${RELEASE} ]]; then
+			mv ${MAIN_BASE_DIR}/WhatsNewContent.md ${MAIN_BASE_DIR}/StaticContent_MD_Output-${RELEASE}/
+		else
+			mkdir -p StaticContent_MD_Output-${RELEASE}
+			mv ${MAIN_BASE_DIR}/WhatsNewContent.md ${MAIN_BASE_DIR}/StaticContent_MD_Output-${RELEASE}/
+		fi
+	
+		echo -e -n "\n${GREEN}* Generated generic whatsnew.md species content. MODIFY AS NEEDED!.${NC}\n"
+	
+		# Generate tracking files and set run next stage
+		touch ${TRACKING}/_s5_whats_new_md
+		RUN_STAGE="Tidy"
+	else
+		echo -e -n "${ORANGE}Must first run stage [4]: 'Image'${NC}\n"
+	fi
+fi
+
+## Tidy output / intermediate files
+if [[ $RUN_STAGE == "All" ]] || [[ $RUN_STAGE == "Tidy" ]]; then
+	echo -e -n "\n\n${ORANGE}*** Tidying up WorkDir data${NC}\n"
+	
+	mkdir -p ${MAIN_BASE_DIR}/Log_Outputs_and_intermediates
+	mkdir -p ${MAIN_BASE_DIR}/$RELEASE
+	STATIC_DIR="StaticContent_MD_Output-${RELEASE}"
+
+#Tidy log files
+for LOG_FILE in generate_Wiki_JSON_Summary.sh Download_species_image_from_url.sh Wikipedia_URL_listed.check.txt wiki_sp2image.tsv Without_Wikipedia_Summary_Content.txt StaticContent_Gen_${RELEASE}_${HOST}.log Output_Image_Licenses.final.tsv
+do
+	if [[ -e $MAIN_BASE_DIR/$LOG_FILE ]]; then
+		echo "Tidying -> [$LOG_FILE]"
+		mv ${MAIN_BASE_DIR}/$LOG_FILE ${MAIN_BASE_DIR}/Log_Outputs_and_intermediates/
+	else
+		echo "Could not find: < $LOG_FILE >....Skipping tiddying."
+	fi
+done
+
+
+#Tidy output folders
+for OUTFOLDER in Commons_Licenses RefSeq_Annotation_Reports RefSeq_Assembly_Reports Source_Images_wikipedia $STATIC_DIR WIKI_JSON_OUT Log_Outputs_and_intermediates ${RELEASE}_checkDone
+do
+	if [[ -e $MAIN_BASE_DIR/$OUTFOLDER ]]; then
+		mv ${MAIN_BASE_DIR}/$OUTFOLDER ${MAIN_BASE_DIR}/$RELEASE/
+	else
+		echo "No <$OUTFOLDER> to tidy..."
+	fi
+done
+echo -e -n "\n* ${GREEN}Log file tidy done! Logs stored here:\n${NC}\"$RELEASE/Log_Outputs_and_intermediates\"\n\n"
+echo -e -n "* ${GREEN}Static content and intermedidate data all stored here:${NC}\n\"${MAIN_BASE_DIR}/$RELEASE\"\n\n"
+echo -e "${GREEN}DONE: All static content procesing finished !!!${NC}"
+fi
+
+exit 0

--- a/scripts/template_about.md
+++ b/scripts/template_about.md
@@ -1,0 +1,13 @@
+**About *scientific_name***
+-------------------------
+
+WIKIPEDIA BLURB ETC....
+
+Picture credit: [LICENSE TYPE]() via Wikimedia Commons [(Image source)](JPG_SOURCE)
+
+Taxonomy ID [TAX_ID](https://www.uniprot.org/taxonomy/TAX_ID)
+
+(Text from [Wikipedia](https://en.wikipedia.org/).)
+
+**More information**
+General information about this species can be found in [Wikipedia](WIKI_URL)

--- a/scripts/template_annotation.md
+++ b/scripts/template_annotation.md
@@ -1,0 +1,9 @@
+**Annotation**
+----------
+
+The annotation presented is derived from annotation submitted to
+[INSDC](http:\/\/www.insdc.org) with the assembly accession [gca_accession_escape](http:\/\/www.ebi.ac.uk\/ena\/data\/view\/GCA_ACCESSION).
+
+Ensembl Metazoa displaying genes imported from [source](SOURCE_URL) annotation release RELEASE_VERSION.
+Small RNA features, protein features, BLAST hits and cross-references have been
+computed by [Ensembl Metazoa](https://metazoa.ensembl.org/info/genome/annotation/index.html).

--- a/scripts/template_assembly.md
+++ b/scripts/template_assembly.md
@@ -1,0 +1,8 @@
+**Assembly**
+--------
+
+The assembly presented here has been imported from [INSDC](http://www.insdc.org) and is linked to the assembly accession [[gca_accession_escape](http://www.ebi.ac.uk/ena/data/view/GCA_ACCESSION)].
+
+The total length of the assembly is XXXX bp contained withinin XXXX scaffolds.
+The scaffold N50 value is XXXXX, the scaffold L50 value is XXX.
+Assembly gaps span XXXXX bp. The GC% content of the assembly is XX.X%.


### PR DESCRIPTION
Addition of Ensembl metazoa static generation Bash + Perl code. 

Pipeline consists of a main Bash wrapper `WikipediaREST_RefSeq_2_static_wrapper.sh`. Which calls on subsequent scripts to generate and format static content (Markdown and Image resources). 

- Static Pipeline obtains data from two main sources: 

1. Wikipedia (_about.md) 
2. NCBI (_assembly.md, _annotation.md)

Image resources are downloaded, while associated licensing information is also retrieved and added to the _about.md file.

REQUIRED OUTSTANDING WORK TO DO:

1. Modify and update README to describe how to run static content pipeline

