### PR TITLE
Addition of standalone wrappers for image downloading & formatting with ImageMagic

### DIFF
--- a/scripts/Format_StaticContent_Images.sh
+++ b/scripts/Format_StaticContent_Images.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/sh
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#convert -define png:size=80x80 Amyelois_transitella_gca001186105v1rs.jpg -thumbnail '80x80>' -background grey -gravity center -extent 80x80 Amyelois_transitella_gca001186105v1rs.png
+
+IN_IMAGE_FORMAT=$1
+PREFIX=$2
+SOURCE_IMAGE_DIR=$3
+OUT_IMAGE_FORMAT="png"
+COLOUR=$4
+
+if [[ -z $IN_IMAGE_FORMAT ]] || [[ -z $PREFIX ]] || [[ -z $SOURCE_IMAGE_DIR ]] || [[ -z $COLOUR ]]; then
+
+	echo -e -n "Usage:\tsh Format_StaticContent_Images.sh <Source image format> <File prefix> <Unformatted Images folder> <Background colour>\nE.g:\n"
+	echo -e -n "Process all images with JPG format:\t\$ sh Format_StaticContent_Images.sh jpg * ./SourceImages/ black\n"
+	echo -e -n "Process all drosophila image files with png format:\t\$ sh Format_StaticContent_Images.sh png Drosophila_* ./SourceImages/ 'rgb(192,192,192)'\n"
+        echo -e -n "Only process Apis_mellifera image:\t\$ sh Format_StaticContent_Images.sh png Apis_mellifera ./SourceImages/ white\n"
+	exit 0
+fi
+
+# Beging processing:
+FOLDER_IN=`readlink -f $SOURCE_IMAGE_DIR`
+mkdir -p tmp_image_processing
+mkdir -p ImageMagick_Formatted_Images
+
+cd ./tmp_image_processing
+
+cp $FOLDER_IN/${PREFIX}.${IN_IMAGE_FORMAT} ./
+
+for IN_IMAGE in ${PREFIX}.${IN_IMAGE_FORMAT}
+do
+	echo "Processing image file: $IN_IMAGE"
+	BASE_NAME=`basename $IN_IMAGE .${IN_IMAGE_FORMAT}`
+	convert -define png:size=80x80 $IN_IMAGE \
+	-thumbnail '80x80>' -background $COLOUR \
+	-gravity center -extent 80x80 \
+	${BASE_NAME}.$OUT_IMAGE_FORMAT
+	echo "Finished image conversion - ${BASE_NAME}.$OUT_IMAGE_FORMAT"
+	mv ${BASE_NAME}.$OUT_IMAGE_FORMAT ../ImageMagick_Formatted_Images
+done
+
+## Cleanup
+cd ../
+rm -rf ./tmp_image_processing
+echo -e -n "Image conversion processing finished! \nSee Outdir --> ImageMagick_Formatted_Images\n"
+
+
+exit

--- a/scripts/Generate_WIKI_Sp_ImagesFromText.sh
+++ b/scripts/Generate_WIKI_Sp_ImagesFromText.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/sh
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+## Generate the list of wikipedia_url, JSON metadata and download available species images from wikipedia using a set of one or more species names.
+## Species name(s) should be prodived as the sole input to this script inside a flat text file. Format = Apis_melifera (one sp per line)
+
+INPUT_SP=$1
+if [ -z $INPUT_SP ]; then
+
+	echo "usage: sh Generate_WIKI_Sp_ImagesFromText.sh <Species_names_infile>"
+	exit 0;
+fi
+
+INPUT_FILE=`readlink -f $INPUT_SP`
+
+function gen_wiki_url (){
+
+	local SCI_NAME=$1
+	local OUT_DIR=$2
+
+	FORMAT_SCI_NAME=`echo $SCI_NAME | sed 's/_/%20/'`;
+	echo -e -ne "Downloading Wikipedia information (JSON) on species: $SCI_NAME\n"
+
+	echo $SCI_NAME | xargs -n 1 -I XXX echo "https://en.wikipedia.org/wiki/XXX" >> Wikipedia_URL_listed.check.txt
+	echo "wget -qq --header='accept: application/json; charset=utf-8' --header 'Accept-Language: en-en' 'https://en.wikipedia.org/api/rest_v1/page/summary/${FORMAT_SCI_NAME}?redirect=true' -O ${OUT_DIR}/${SCI_NAME}.wiki.json" >> download_Wiki_JSON_Summary.sh
+}
+
+# Generate the WIikipedia JSON download script and download JSON file per species.
+mkdir -p WIKI_JSON
+export WIKI_DIR=`readlink -f WIKI_JSON`
+cd $WIKI_DIR
+rm -f ./download_Wiki_JSON_Summary.sh
+
+while read SPECIES
+do
+gen_wiki_url $SPECIES $WIKI_DIR
+done < $INPUT_FILE
+cd ..
+
+# Run download of Wiki JSONs
+`sh $WIKI_DIR/download_Wiki_JSON_Summary.sh`
+echo "....done"
+
+# Process images using input JSON folder
+echo "Downloading species source image(s)"
+`sh Image_resource_gather.sh $WIKI_DIR 2>&1 | tee image_download.log`
+echo "....done"
+
+echo -e -n "\n\n### Log from image downloading:\n"
+cat ./image_download.log
+
+#Clean up
+rm ./temp_output_license.tsv
+
+exit 0


### PR DESCRIPTION
PR contained two wrappers for Obtaining and processing species images:

1) Download a set of one or more species images from wikipedia, using species name(s) as the sole input. This differs from the main static pipeline wrapper based on core_dbs & RefSeq URLs. Useful for when we need to update/modify images and licensing information for already existing species on e! main
2) A wrapper to format and convert species images from wikipedia to be correctly formatted into PNG and resized, using appropriate background colours etc (options to wrapper). 