### PR TITLE
Change random gene query to restrict to PCGs only

### DIFF
--- a/scripts/legacy/set_core_samples.pl
+++ b/scripts/legacy/set_core_samples.pl
@@ -100,8 +100,8 @@ push @$optsd, "gene_id:s";
 my $opts = $cli_helper->process_args( $optsd, \&pod2usage );
 
 if ( !$opts->{user} ||
-     !$opts->{pass}          ||
-     !$opts->{host}          ||
+     !$opts->{pass} ||
+     !$opts->{host} ||
      !$opts->{port}) {
     pod2usage(1);
 }

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -1969,7 +1969,7 @@ function set_core_random_samples () {
     fi
 
     if [ -z "$SAMPLE_GENE" ]; then
-      local RAND_GENE=$($CMD -D "$DBNAME" -N -e 'select stable_id from gene order by rand() limit 1;')
+      local RAND_GENE=$($CMD -D "$DBNAME" -N -e 'SELECT stable_id FROM gene g LEFT JOIN seq_region sr ON g.seq_region_id = sr.seq_region_id LEFT JOIN coord_system USING (coord_system_id) where g.biotype = "protein_coding" AND coord_system.name = "primary_assembly" ORDER BY RAND() LIMIT 1;')
       echo "using $RAND_GENE as sample" >> /dev/stderr
       SAMPLE_GENE="$RAND_GENE"
     fi

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -1969,7 +1969,7 @@ function set_core_random_samples () {
     fi
 
     if [ -z "$SAMPLE_GENE" ]; then
-      local RAND_GENE=$($CMD -D "$DBNAME" -N -e 'SELECT stable_id FROM gene g LEFT JOIN seq_region sr ON g.seq_region_id = sr.seq_region_id LEFT JOIN coord_system USING (coord_system_id) where g.biotype = "protein_coding" AND coord_system.name = "primary_assembly" ORDER BY RAND() LIMIT 1;')
+      local RAND_GENE=$($CMD -D "$DBNAME" -N -e 'select g.stable_id FROM gene g INNER JOIN seq_region_attrib USING (seq_region_id) INNER JOIN attrib_type at USING (attrib_type_id) WHERE g.biotype='protein_coding' AND at.name = "Top Level" ORDER BY RAND() LIMIT 1;')
       echo "using $RAND_GENE as sample" >> /dev/stderr
       SAMPLE_GENE="$RAND_GENE"
     fi


### PR DESCRIPTION
Slightly modified query used in lib.sh to select gene.stable_id. 
-Changed to only select when biotype = 'protein_coding'
-Further restricted selection of gene to seq_regions linked to `primary_assembly`