### PR TITLE
Fixing the use of Sylabs dataset-cli image to new dockerhub: ensemblorg

### DIFF
--- a/scripts/static_content_generation/CoreList_To_StaticContent.sh
+++ b/scripts/static_content_generation/CoreList_To_StaticContent.sh
@@ -137,8 +137,8 @@ if [[ $RUN_STAGE == "ALL" ]] || [[ $RUN_STAGE == "NCBI" ]]; then
 		SING_PRESENT=`which singularity`
 		if [[ $SING_PRESENT ]]; then
 
-			# Download the ncbi-datasets singularity image:
-			echo -e -n "Attempting to retrive NCBI datasets-cli from dockerhub 'https://hub.docker.com/r/ensemblorg/datasets-cli':\n\
+			# Download the ncbi-datasets singularity image from docker hub https://hub.docker.com/r/ensemblorg/datasets-cli:
+			echo -e -n "Attempting to retrive NCBI datasets-cli from docker 'ensemblorg/datasets-cli':\n\
 			Image Tag -> '$DATASETS_DOCKER_URL'"
 
 			singularity pull --arch amd64 $DATASETS_SINGULARITY $DATASETS_DOCKER_URL

--- a/scripts/static_content_generation/Image_resource_gather.sh
+++ b/scripts/static_content_generation/Image_resource_gather.sh
@@ -164,15 +164,22 @@ do
 	fi
 done
 
-echo -e -n "\n\n${RED}***** Unavailable image resources. JSON file(s) *****\n"
-cat wiki_sp2image.tsv | grep -e "NO SPECIES IMAGE FOUND" | awk {'print $1'}
-echo -e -n "****************************************************${NC}\n\n"
+# Check if there were species without available image files on wiki
+COUNT_MISSING_IMAGES=`cat wiki_sp2image.tsv | grep -c "NO SPECIES IMAGE FOUND"`
+if [[ $COUNT_MISSING_IMAGES = 0 ]]; then
+	echo -e -n "\n${GREEN}Great news. All species have images to pull from wikipedia !${NC}\n\n"
+	sleep 2
+else
+	echo -e -n "\n\n${RED}***** Unavailable image resources. JSON file(s) *****\n"
+	cat wiki_sp2image.tsv | grep -e "NO SPECIES IMAGE FOUND" | awk {'print $1'}
+	echo -e -n "****************************************************${NC}\n\n"
+fi
 cat wiki_sp2image.tsv | grep -v "NO SPECIES IMAGE FOUND" > wiki_sp2image_NoMissing.tsv
 
-## Move all species source image files into single folder
+## Move all source image files into single folder
 if [[ -e ${CWD}/Download_species_image_from_url.sh ]]; then
 
-	echo -e -n "!! Downloading all original species source images to folder [20s timeout between image retrieval]:\n--> \"${CWD}/Source_Images_wikipedia\" !!\n\n"
+	echo -e -n "!! Downloading all original species source images to folder [20s timeout between image retrieval]:\n\n"
 
 	sh ${CWD}/Download_species_image_from_url.sh
 	mkdir -p $CWD/Source_Images_wikipedia


### PR DESCRIPTION
- Small improvements to code readability and variable definitions 
- Replace all instance of sylabs endpoint in favour of ensemblorg datasets-cli. Script will attempt to pull latest version of datasets
- Improved how main wrapper pulls specific or latest datasets-cli version. Tries to get specific latest and name SIF image with that version, or then try to get on 'latest' tag. 
- Improved user reporting on potential missing species image files from wikipedia