### PR TITLE
An update to the template for running genome loading production via ensembl-mod-env

### DIFF
--- a/scripts/_template_ProcessEnsemblGenomeLoading.slurm.sh
+++ b/scripts/_template_ProcessEnsemblGenomeLoading.slurm.sh
@@ -1,56 +1,155 @@
 #!/usr/bin/bash
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-## set and ENS_VERSION and MZ_RELEASE number
-ENS_VERSION= # e.g 111
-MZ_RELEASE=$(( ${ENS_VERSION} - 53 ))
-MAIN_BASE_DIR= #Work dir, location of base working space for loading
-SLURM_BATCH_TEMPLATE= #Template containing sbatch params used to construct `sptags_batch_#' Slurm submission batch file
+####################
+### Create ensembl-mod-env for genome load production processing:
+# Step1: get latest updates to ensembl-mod-env repo ! This is critical to ensure proper functionality. 
+# Step2: Select appropriate python version, this e.g. use relatively latest python version v3.11.7
+  # - module load python/3.11.7
+# Step3: Create production environment, using load_genome.conf (https://github.com/Ensembl/ensembl-mod-env/blob/main/confs/ensembl/load_genome.yml)
+# whilst selecting the base branch to be the same as the ensembl schema version for the core creation [ENS_VERSION]
+  # - E.g. modenv_create -b 114 ensembl/load_genome e114_genomeload
+## Load module env, you will need to do this manually outside of this wrapper
+  # -E.g.  module load ensembl/e114_genomeload
+####################
 
-if [[ -z $ENS_VERSION ]] | [[ -z $MZ_RELEASE ]] | [[ -z $MAIN_BASE_DIR ]] | [[ -z $SLURM_BATCH_TEMPLATE ]]; then
-
-    echo "Ensure following vars are defined: ENS_VERSION, MZ_RELEASE, MAIN_BASE_DIR, SLURM_BATCH_TEMPLATE"
-    exit
+## set and ENS_VERSION
+if [[ $ENSEMBL_VERSION ]]; then
+  ENS_VERSION=$ENSEMBL_VERSION
+  echo "ENSEMBL VERSION detected: '$ENS_VERSION'"
+else
+  # e.g 111 i.e. the ensembl schema version to use for loading
+  ENS_VERSION=""
+  if [[ -z $ENS_VERSION ]]; then
+    echo "Please define the ENSEMBL VERSION: ENS_VERSION, See $0 (line: 35)"
+    exit 0
+  fi
 fi
 
-## default server aliases
-CMD=me1 #Mysql host in which loaded cores are stored
-PROD_SERVER=meta1
-QUEUE=production
+##### How to set up the main production environment.
+# METHOD A: Setup when using ensembl-mod-env for production
+# If using mod-env you must ensure the environment variable MODENV_ROOT is defined !
+if [[ $MODENV_ROOT ]] && [[ $MODENV_HOME ]]; then
+  echo "Detecting 'ensembl-mod-env' production environment setup...."
+  PRODUCTION_MODENV_NAME="" #< E.G. NOTE: Ensure MODENV_DIR DOESN'T END WITH: "/"
+  if [[ $PRODUCTION_MODENV_NAME ]]; then
+    MODENV_DIR="${MODENV_HOME}/${PRODUCTION_MODENV_NAME}" ## MODENV_ROOT must be defined and should be if ensembl-mod-env is correctly setup for $USER
+    echo "Using modenv setup ?.... if so its configured to this path: '$MODENV_DIR'"
+    ENS_MAIN_METAZOA_PROD=${MODENV_DIR}/ensembl-production-metazoa
+    ln -s $ENS_MAIN_METAZOA_PROD ./ensembl-production-metazoa
+    ln -s $MODENV_DIR ./ensembl.prod.${ENS_VERSION}
+    echo "'venv' path ->: '${VENV_ROOT}/${PRODUCTION_MODENV_NAME}/bin'"
+    echo "'modenv' created module repos ->: '$MODENV_DIR'"
+  else
+    echo "Named ensembl-mod-env module not defined 'PRODUCTION_MODENV_NAME' ! See $0 (line: 47)"
+    exit 0
+  fi
+# METHOD B: Setup when using 'mz_generic.sh env_setup_only'
+elif [[ -d "${PWD}/ensembl.prod.${ENS_VERSION}" ]]; then
+  echo "Attempting to detect standard 'ensembl.prod.${ENS_VERSION}' non-module-env production environment setup"
+  STANDARD_REPO_SETUP="$PWD/ensembl.prod.${ENS_VERSION}"
+  ENS_MAIN_METAZOA_PROD="$PWD/ensembl.prod.${ENS_VERSION}/ensembl-production-metazoa"
+  echo "'venv' path ->: '${STANDARD_REPO_SETUP}/venv/bin'"
+  echo "'standard setup' repos ->: '$STANDARD_REPO_SETUP'"
+else
+  echo "Unable to resolve production environment setup to standard ensembl.prod OR ensembl-mod-env !"
+  echo "Standard setup procedure:"
+  echo "git clone --depth 1 -b main git@github.com:Ensembl/ensembl-production-metazoa.git"
+  echo "ensembl-production-metazoa/scripts/mz_generic.sh env_setup_only"
+  exit 1
+fi
 
-## LSF Legacy stuff:
-# export PROD_SERVER
-# export CMD
-# export ENS_VERSION
-# export MZ_RELEASE
-# LSF_QUEUE=production # LSF queue which runs loading/production pipelines
+## set basic requirement env setup vars
+PROD_CYCLE_ENS_VERSION=$(( ${ENS_VERSION} + 1 )) # The production release version for which we are running genome loading.
+MZ_RELEASE=$(( ${ENS_VERSION} - 53 ))
+WORK_DIR=${PWD} #Path to base work directory space for running genome load
 
-## TMUX session connections
-# TMUX CREATE:
-# tmux -S /tmp/${USER}_e${ENS_VERSION}_load new -s ${USER}_e${ENS_VERSION}_load
-# TMUX ATTACH:
-# tmux -S /tmp/${USER}_e${ENS_VERSION}_load att -t ${USER}_e${ENS_VERSION}_load
+#Template containing sbatch params used to construct `sptags_batch_#' Slurm submission batch file
+SLURM_BATCH_TEMPLATE="${ENS_MAIN_METAZOA_PROD}/scripts/_template_slurm_jobscript.batch"
 
-## How to set up the main production environment.
-# ${ENS_MAIN_METAZOA_PROD}/scripts/mz_generic.sh env_setup_only
+if [[ ! -e $SLURM_BATCH_TEMPLATE ]]; then
+    echo "Could not find slurm batch submission template (SLURM_BATCH_TEMPLATE) here: $SLURM_BATCH_TEMPLATE"
+    exit 0
+else
+  echo "Using slurm batch tempalte: $SLURM_BATCH_TEMPLATE"
+fi
+
+## Host setup, dbs and SLURM queue config
+CMD= #Mysql host in which new core DBs will be created and stored (e.g: me1, me2, pl1, pl2)
+PROD_SERVER= # Host containing production 'ensembl_production' db
+QUEUE=production # QUEUE/PARTITION FOR SLURM SCHEDULER:
+if [[ -z $CMD ]] || [[ -z $PROD_SERVER ]] || [[ -z $QUEUE ]]; then
+    echo "Ensure following environment vars are defined: CMD, PROD_SERVER, QUEUE"
+    exit 0
+fi
+
+## WHAT ORGANISM DIVISION ARE YOU LOADING ?
+LOAD_DIVISION=
+# Check an appropriate division was supplied by user
+if [[ -z $LOAD_DIVISION ]]; then
+	echo "Organism division not defined. Please define on $0 (line: 100)"
+  exit
+elif [[ "$LOAD_DIVISION" != "metazoa" ]] && [[ "$LOAD_DIVISION" != "plants" ]]; then
+	echo -e -n "Division supplied ('$LOAD_DIVISION') not recognised. Must be defined as: [ metazoa | plants ]\n\n"
+	exit 1
+else
+  echo "Division defined -> '$LOAD_DIVISION'"
+fi
 
 ## Set up of ensembl-production-metazoa production repo
-cd $MAIN_BASE_DIR; mkdir -p workdir tmp logs data locks
+cd $WORK_DIR; mkdir -p workdir tmp logs data locks
 
 # Requires https://github.com/Ensembl/ensembl-production-metazoa
-# git clone --depth 1 -b main git@github.com:Ensembl/ensembl-production-metazoa.git
-ENS_MAIN_METAZOA_PROD=${MAIN_BASE_DIR}/ensembl-production-metazoa
-METACONF_DIR=$ENS_MAIN_METAZOA_PROD/meta/2024-01.release_XXX  #Space in which meta files are stored for a given release.
-mkdir -p $METACONF_DIR
+CONF_DIR_NAME=`date -I`
+# If specific loading meta configuration folder already exists with config files generated...define it on next line:
+# METACONF_DIR=""
+# Or we attempt to build it from other configs defined:
+METACONF_DIR=$ENS_MAIN_METAZOA_PROD/meta/${CONF_DIR_NAME}.${ENS_VERSION}_for_${PROD_CYCLE_ENS_VERSION}  #Space in which meta files are stored for a given release.
+# Create METACONF_DIR if it doesn't already exist
+if [[ ! -d "$METACONF_DIR" ]]; then
+    # mkdir -p $METACONF_DIR
+    echo "Could not set METACONF_DIR. Path doesn't exist -> '$ENS_MAIN_METAZOA_PROD/meta/${CONF_DIR_NAME}.${ENS_VERSION}_for_${PROD_CYCLE_ENS_VERSION}'"
+    echo "You will need to manually create this conf dir and loading meta config files, see $0 (line: 128)"
 
-# echo tmp workdir | xargs -n 1 | xargs -n 1 -I XXX sh -c 'mv XXX XXX.old; mkdir -p XXX; rm -rf XXX.old;'
-# SPECIES_TO_LOAD_META=_refseq_e${ENS_VERSION}.list # This list is prepared by hand using input from curated spreadsheet (e.g. https://github.com/Ensembl/ensembl-production-metazoa/blob/main/meta/107_for_109/_refseq_109.lst)
-# python3 ${ENS_MAIN_METAZOA_PROD}/scripts/tmpl2meta.py --template ${ENS_MAIN_METAZOA_PROD}/meta/refseq.tmpl --param_table $METACONF_DIR/_refseq_e${ENS_VERSION}.list --output_dir $METACONF_DIR --out_file_pfx rs8t_
+    # ## If no config files exist for your release loading, create them:
+    # echo tmp workdir | xargs -n 1 | xargs -n 1 -I XXX sh -c 'mv XXX XXX.old; mkdir -p XXX; rm -rf XXX.old;'
+    # SPECIES_TO_LOAD_META=${METACONF_DIR}_refseq_e${ENS_VERSION}.list # This list is prepared by hand using input from curated spreadsheet (e.g. https://github.com/Ensembl/ensembl-production-metazoa/blob/main/meta/2025-01-15.114_for_115/_refseq_e115.list)
+    # CONFIG_DIVISION="${LOAD_DIVISION}.tmpl" # E.G. https://github.com/Ensembl/ensembl-production-metazoa/blob/main/meta/metazoa.tmpl
+    # CONFIG_TEMPLATE=${ENS_MAIN_METAZOA_PROD}/meta/$CONFIG_DIVISION
+    # OUT_PREFIX="rs8t_" # legacy standard, but feel free to use whatever you prefer
+    # python ${ENS_MAIN_METAZOA_PROD}/scripts/tmpl2meta.py \
+    #   --template $CONFIG_TEMPLATE \
+    #   --param_table $SPECIES_TO_LOAD_META \
+    #   --output_dir $METACONF_DIR \
+    #   --out_file_pfx $OUT_PREFIX
+else
+  echo "'METACONF_DIR' var defined -> '$METACONF_DIR'"
+fi
 
 ### Processing meta_conf to generate batches of species to load (Batch file prefix: sptags_batch_#)
 # BATCH_SIZE=4 # Number of species to load in one batch submission
 # ls -1 $METACONF_DIR/rs8t_* | \
 # perl -pe 's,.*/,,' | \
 # xargs -n 1 echo | split --numeric-suffixes=1 -l $BATCH_SIZE - sptags_batch_
+
+## TMUX session connections reminder:
+# TMUX CREATE:
+# tmux -S /tmp/${USER}_e${ENS_VERSION}_load new -s ${USER}_e${ENS_VERSION}_genome_load
+# TMUX ATTACH:
+# tmux -S /tmp/${USER}_e${ENS_VERSION}_load att -t ${USER}_e${ENS_VERSION}_genome_load
 
 ### Genome Loading and Processing starts from here:
 
@@ -60,14 +159,26 @@ BATCH_NO="BATCH_1_ROUND1"
 # BATCH_NO="BATCH_3_ROUND1"
 # BATCH_NO="BATCH_4_ROUND1"
 # BATCH_NO="BATCH_5_ROUND1"
+# BATCH_NO=......."
+# BATCH_NO=......."
+# BATCH_NO=......."
 # BATCH_NO="CUSTOM"
+
+### mz_generic params:
+## SEE (https://github.com/Ensembl/ensembl-production-metazoa/blob/main/docs/mz_generic_params.md)
+MZGEN_MODE="stop_after_conf"
+# MZGEN_MODE="stop_after_load"
+# MZGEN_MODE="stop_before_xref"
+# MZGEN_MODE="pre_final_dc"
+# MZGEN_MODE="finalise"
 
 ## Species batch number 1:
 if [ "$BATCH_NO" == "BATCH_1_ROUND1" ]; then
 
 BATCH_FILE=sptags_batch_01
-MODE="stop_after_load" # SEE (https://github.com/Ensembl/ensembl-production-metazoa/blob/main/docs/mz_generic_params.md)
-SLEEP=7200 #Time to wait between genome load, useful to not throttle cluster when loading large genomes with very long chromosomes.
+MODE=$MZGEN_MODE
+#Time to wait between genome load, useful to not throttle cluster when loading large genomes with very long chromosomes.
+SLEEP=7200
 
 while read TAG
 do
@@ -80,7 +191,7 @@ do
   sbatch ${TAG}_slurm_batch.sh | tee logs/${TAG}.sbatch_ID
   echo "Submitted $TAG. Now sleeping for [${SLEEP}] seconds ..."
   sleep $SLEEP
-done < ${MAIN_BASE_DIR}/${BATCH_FILE}
+done < ${WORK_DIR}/${BATCH_FILE}
 
 fi
 
@@ -90,7 +201,7 @@ if [ "$BATCH_NO" == "BATCH_2_ROUND1" ]; then
 cat sptags_batch_02 |
 
 BATCH_FILE=sptags_batch_02
-MODE="stop_after_load"
+MODE=$MZGEN_MODE
 SLEEP=7200
 
 while read TAG
@@ -104,7 +215,7 @@ do
   sbatch ${TAG}_slurm_batch.sh | tee logs/${TAG}.sbatch_ID
   echo "Submitted $TAG. Now sleeping for [${SLEEP}] seconds ..."
   sleep $SLEEP
-done < ${MAIN_BASE_DIR}/${BATCH_FILE}
+done < ${WORK_DIR}/${BATCH_FILE}
 
 fi
 
@@ -112,7 +223,7 @@ fi
 if [ "$BATCH_NO" == "BATCH_3_ROUND1" ]; then
 
 BATCH_FILE=sptags_batch_03
-MODE="stop_after_load"
+MODE=$MZGEN_MODE
 SLEEP=7200
 
 while read TAG
@@ -126,7 +237,7 @@ do
   sbatch ${TAG}_slurm_batch.sh | tee logs/${TAG}.sbatch_ID
   echo "Submitted $TAG. Now sleeping for [${SLEEP}] seconds ..."
   sleep $SLEEP
-done < ${MAIN_BASE_DIR}/${BATCH_FILE}
+done < ${WORK_DIR}/${BATCH_FILE}
 
 fi
 
@@ -134,7 +245,7 @@ fi
 if [ "$BATCH_NO" == "BATCH_4_ROUND1" ]; then
 
 BATCH_FILE=sptags_batch_04
-MODE="stop_after_load"
+MODE=$MZGEN_MODE
 SLEEP=7200
 
 while read TAG
@@ -148,7 +259,7 @@ do
   sbatch ${TAG}_slurm_batch.sh | tee logs/${TAG}.sbatch_ID
   echo "Submitted $TAG. Now sleeping for [${SLEEP}] seconds ..."
   sleep $SLEEP
-done < ${MAIN_BASE_DIR}/${BATCH_FILE}
+done < ${WORK_DIR}/${BATCH_FILE}
 
 fi
 
@@ -156,7 +267,7 @@ fi
 if [ "$BATCH_NO" == "BATCH_5_ROUND1" ]; then
 
 BATCH_FILE=sptags_batch_05
-MODE="stop_after_load"
+MODE=$MZGEN_MODE
 SLEEP=7200
 
 while read TAG
@@ -170,7 +281,7 @@ do
   sbatch ${TAG}_slurm_batch.sh | tee logs/${TAG}.sbatch_ID
   echo "Submitted $TAG. Now sleeping for [${SLEEP}] seconds ..."
   sleep $SLEEP
-done < ${MAIN_BASE_DIR}/${BATCH_FILE}
+done < ${WORK_DIR}/${BATCH_FILE}
 
 fi
 
@@ -178,7 +289,7 @@ fi
 if [ "$BATCH_NO" == "CUSTOM" ]; then
 
 BATCH_FILE=sptags_batch_custom
-MODE="stop_after_load"
+MODE=$MZGEN_MODE
 SLEEP=7200
 
 while read TAG
@@ -192,6 +303,6 @@ do
   sbatch ${TAG}_slurm_batch.sh | tee logs/${TAG}.sbatch_ID
   echo "Submitted $TAG. Now sleeping for [${SLEEP}] seconds ..."
   sleep $SLEEP
-done < ${MAIN_BASE_DIR}/${BATCH_FILE}
+done < ${WORK_DIR}/${BATCH_FILE}
 
 fi

--- a/scripts/_template_ProcessEnsemblGenomeLoading.slurm.sh
+++ b/scripts/_template_ProcessEnsemblGenomeLoading.slurm.sh
@@ -198,8 +198,6 @@ fi
 ## Species batch number 2:
 if [ "$BATCH_NO" == "BATCH_2_ROUND1" ]; then
 
-cat sptags_batch_02 |
-
 BATCH_FILE=sptags_batch_02
 MODE=$MZGEN_MODE
 SLEEP=7200

--- a/scripts/_template_ProcessEnsemblGenomeLoading.slurm.sh
+++ b/scripts/_template_ProcessEnsemblGenomeLoading.slurm.sh
@@ -24,6 +24,8 @@
   # - E.g. modenv_create -b 114 ensembl/load_genome e114_genomeload
 ## Load module env, you will need to do this manually outside of this wrapper
   # -E.g.  module load ensembl/e114_genomeload
+## Load module env for hive, you will need to do this manually outside of this wrapper
+  # -E.g.  module load hive/2.7.0
 ####################
 
 ## set and ENS_VERSION

--- a/scripts/_template_ProcessEnsemblGenomeLoading.slurm.sh
+++ b/scripts/_template_ProcessEnsemblGenomeLoading.slurm.sh
@@ -28,7 +28,7 @@
   # -E.g.  module load hive/2.7.0
 ####################
 
-## set and ENS_VERSION
+## set ENS_VERSION
 if [[ $ENSEMBL_VERSION ]]; then
   ENS_VERSION=$ENSEMBL_VERSION
   echo "ENSEMBL VERSION detected: '$ENS_VERSION'"
@@ -158,7 +158,7 @@ fi
 
 ### Genome Loading and Processing starts from here:
 
-## Uncomment lines as needed
+## Uncomment lines as needed to run different sptags batches. Only one BATCH_NO should be uncommented at a time
 BATCH_NO="BATCH_1_ROUND1"
 # BATCH_NO="BATCH_2_ROUND1"
 # BATCH_NO="BATCH_3_ROUND1"
@@ -169,7 +169,7 @@ BATCH_NO="BATCH_1_ROUND1"
 # BATCH_NO=......."
 # BATCH_NO="CUSTOM"
 
-### mz_generic params:
+### mz_generic params, this will set the level of throughput in genome loading and production pipeline processing:
 ## SEE (https://github.com/Ensembl/ensembl-production-metazoa/blob/main/docs/mz_generic_params.md)
 MZGEN_MODE="stop_after_conf"
 # MZGEN_MODE="stop_after_load"

--- a/scripts/_template_ProcessEnsemblGenomeLoading.slurm.sh
+++ b/scripts/_template_ProcessEnsemblGenomeLoading.slurm.sh
@@ -32,7 +32,7 @@ if [[ $ENSEMBL_VERSION ]]; then
   echo "ENSEMBL VERSION detected: '$ENS_VERSION'"
 else
   # e.g 111 i.e. the ensembl schema version to use for loading
-  ENS_VERSION=""
+  ENS_VERSION=
   if [[ -z $ENS_VERSION ]]; then
     echo "Please define the ENSEMBL VERSION: ENS_VERSION, See $0 (line: 35)"
     exit 0
@@ -44,7 +44,9 @@ fi
 # If using mod-env you must ensure the environment variable MODENV_ROOT is defined !
 if [[ $MODENV_ROOT ]] && [[ $MODENV_HOME ]]; then
   echo "Detecting 'ensembl-mod-env' production environment setup...."
+  
   PRODUCTION_MODENV_NAME="" #< E.G. NOTE: Ensure MODENV_DIR DOESN'T END WITH: "/"
+
   if [[ $PRODUCTION_MODENV_NAME ]]; then
     MODENV_DIR="${MODENV_HOME}/${PRODUCTION_MODENV_NAME}" ## MODENV_ROOT must be defined and should be if ensembl-mod-env is correctly setup for $USER
     echo "Using modenv setup ?.... if so its configured to this path: '$MODENV_DIR'"
@@ -56,7 +58,8 @@ if [[ $MODENV_ROOT ]] && [[ $MODENV_HOME ]]; then
   else
     echo "Named ensembl-mod-env module not defined 'PRODUCTION_MODENV_NAME' ! See $0 (line: 47)"
     exit 0
-  fi
+  fi # < PRODUCTION_MODENV_NAME
+
 # METHOD B: Setup when using 'mz_generic.sh env_setup_only'
 elif [[ -d "${PWD}/ensembl.prod.${ENS_VERSION}" ]]; then
   echo "Attempting to detect standard 'ensembl.prod.${ENS_VERSION}' non-module-env production environment setup"
@@ -70,7 +73,7 @@ else
   echo "git clone --depth 1 -b main git@github.com:Ensembl/ensembl-production-metazoa.git"
   echo "ensembl-production-metazoa/scripts/mz_generic.sh env_setup_only"
   exit 1
-fi
+fi # <[[ $MODENV_ROOT ]] && [[ $MODENV_HOME ]]
 
 ## set basic requirement env setup vars
 PROD_CYCLE_ENS_VERSION=$(( ${ENS_VERSION} + 1 )) # The production release version for which we are running genome loading.
@@ -113,15 +116,15 @@ fi
 cd $WORK_DIR; mkdir -p workdir tmp logs data locks
 
 # Requires https://github.com/Ensembl/ensembl-production-metazoa
-CONF_DIR_NAME=`date -I`
+CONF_DIR_DATE=`date -I`
 # If specific loading meta configuration folder already exists with config files generated...define it on next line:
 # METACONF_DIR=""
 # Or we attempt to build it from other configs defined:
-METACONF_DIR=$ENS_MAIN_METAZOA_PROD/meta/${CONF_DIR_NAME}.${ENS_VERSION}_for_${PROD_CYCLE_ENS_VERSION}  #Space in which meta files are stored for a given release.
+METACONF_DIR=$ENS_MAIN_METAZOA_PROD/meta/${CONF_DIR_DATE}.${ENS_VERSION}_for_${PROD_CYCLE_ENS_VERSION}  #Space in which meta files are stored for a given release.
 # Create METACONF_DIR if it doesn't already exist
 if [[ ! -d "$METACONF_DIR" ]]; then
     # mkdir -p $METACONF_DIR
-    echo "Could not set METACONF_DIR. Path doesn't exist -> '$ENS_MAIN_METAZOA_PROD/meta/${CONF_DIR_NAME}.${ENS_VERSION}_for_${PROD_CYCLE_ENS_VERSION}'"
+    echo "Could not set METACONF_DIR. Path doesn't exist -> '$ENS_MAIN_METAZOA_PROD/meta/${CONF_DIR_DATE}.${ENS_VERSION}_for_${PROD_CYCLE_ENS_VERSION}'"
     echo "You will need to manually create this conf dir and loading meta config files, see $0 (line: 128)"
 
     # ## If no config files exist for your release loading, create them:


### PR DESCRIPTION
Updated the template to be flexible with regard to using a standard setup (env_setup via mz_generic) or via ensembl-mod-env

The template requires some configuration at the start of production setup but it should ensure proper functionality for batch submitting genome loading pipelines. 

Tested its use during e115 ensembl-mod-env production testing. 