### PR TITLE
adding "#CONF_IF" support for the template engine

### DIFF
--- a/meta/metazoa.tmpl
+++ b/meta/metazoa.tmpl
@@ -20,9 +20,9 @@ species.common_name	_COMMON_NAME_
 #CONF	ASM_URL	_GENOME_FTP_URL_
 
 # Community GFF3 loading
-#no CONF	DATA_INIT	zcat _ANNOTATION_GFF3_ | cat > fixed.gff3
-#no CONF	GFF_FILE	fixed.gff3
-#no CONF	PEP_FILE	pep.faa
+#CONF_IF_ANNOTATION_GFF3_	DATA_INIT	zcat _ANNOTATION_GFF3_ | cat > fixed.gff3
+#CONF_IF_ANNOTATION_GFF3_	GFF_FILE	fixed.gff3
+#CONF_IF_ANNOTATION_GFF3_	PEP_FILE	pep.faa
 
 # RefSeq related defaults
 #no CONF	GCF_TO_GCA	1

--- a/meta/plants.tmpl
+++ b/meta/plants.tmpl
@@ -22,8 +22,8 @@ species.common_name	_COMMON_NAME_
 #no CONF	FNA_FILE	_ASSEMBLY_FASTA_
 
 # Community GFF3 loading
-#CONF	DATA_INIT	zcat _ANNOTATION_GFF3_ | cat > fixed.gff3
-#CONF	GFF_FILE	fixed.gff3
+#CONF_IF_ANNOTATION_GFF3_	DATA_INIT	zcat _ANNOTATION_GFF3_ | cat > fixed.gff3
+#CONF_IF_ANNOTATION_GFF3_	GFF_FILE	fixed.gff3
 #no CONF	PEP_FILE	pep.faa
 
 # RefSeq related defaults

--- a/scripts/tmpl2meta.py
+++ b/scripts/tmpl2meta.py
@@ -55,6 +55,10 @@ def fill_template(template : str, conf : dict, name_field : str, dir_path : str,
     # sort keys first by length, then alphabetically to fix "_A_" and "_A_SFX_" case
     for expr, subst in sorted(conf.items(), key = lambda p: (-len(p[0]), p[0])):
       template = template.replace(expr, subst)
+    # process "#CONF_IF" entries
+    template = re.sub(r"^#CONF_IF +\t", "#CONF_IF\t", template, flags=re.MULTILINE)
+    template = re.sub(r"^#CONF_IF[^\t]+\t", "#CONF\t", template, flags=re.MULTILINE)
+    template = re.sub(r"^#CONF_IF\t", "#no CONF\t", template, flags=re.MULTILINE)
     outfile.write(template)
   return
 


### PR DESCRIPTION
```
#CONF_IF_ANNOTATION_GFF3_      DATA_INIT       zcat _ANNOTATION_GFF3_ | cat > fixed.gff3
```
will be rendered to
```
#no CONF      DATA_INIT       zcat | cat > fixed.gff3
```
if `_ANNOTATION_GFF3_` is  empty (or starts with tab `\t`);
or to a proper 
```
#CONF      DATA_INIT       zcat SOME | cat > fixed.gff3
```
if `_ANNOTATION_GFF3_` is defined (and has no tabs)

NB "starting" with tab (`\t`) or having tab is not that possible at the moment as it breaks many things anyway